### PR TITLE
Propagate error from `main` automatically

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,14 +144,11 @@ pub enum RuleInst {
 fn main() -> Result<(), Box<dyn Error>> {
     let table_def = include_str!("potion.tbl");
 
-    match Tabol::new(table_def.trim()) {
-        Err(error) => return Err(Box::new(error)),
-        Ok(tabol) => {
-            println!("{:#?}", tabol);
-            println!("table ids: {:?}", tabol.table_ids());
-            println!("{:#?}", tabol.gen_many("potion", 20));
-        }
-    };
+    let tabol = Tabol::new(table_def.trim())?;
+
+    println!("{:#?}", tabol);
+    println!("table ids: {:?}", tabol.table_ids());
+    println!("{:#?}", tabol.gen_many("potion", 20));
 
     Ok(())
 }


### PR DESCRIPTION
Cool to see you exploring Rust as well!  I came across your repo in my Github feed and thought I'd share something I learned when improving the error handling I did in a little [migration utility](https://github.com/reagent/rust-migrator/pull/2) I'm working on.

Since you're returning a `Result` from `main`, you can just use the [question mark operator](http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/reference/expressions/operator-expr.html#the-question-mark-operator) to automatically propagate the error without having to `match` it and return it.  

